### PR TITLE
Improve session invocation

### DIFF
--- a/src/baserun.ts
+++ b/src/baserun.ts
@@ -62,10 +62,9 @@ export type TraceOptions = {
   name?: string;
 };
 
-export type SessionOptions<T extends (...args: any[]) => any> = {
+export type SessionOptions = {
   user: string;
   sessionId?: string;
-  session: T;
 };
 
 process.on('exit', () => {
@@ -318,11 +317,10 @@ export class Baserun {
     };
   }
 
-  static async session<T extends (...args: any[]) => any>({
-    session: fn,
-    sessionId,
-    user,
-  }: SessionOptions<T>): Promise<{ sessionId?: string; data: ReturnType<T> }> {
+  static async session<T extends (...args: any[]) => any>(
+    fn: T,
+    { sessionId, user }: SessionOptions,
+  ): Promise<{ sessionId?: string; data: Awaited<ReturnType<T>> }> {
     debug('calling session()');
     if (!Baserun.ensureInitialized()) {
       return { data: await fn() };

--- a/src/vitests/sessions.test.ts
+++ b/src/vitests/sessions.test.ts
@@ -37,8 +37,8 @@ describe('sessions', () => {
   });
 
   test('session', async () => {
-    await baserun.session({
-      async session() {
+    await baserun.session(
+      async function () {
         await baserun.trace(async () => {
           baserun.log('lets go', 'omg');
           await openai.completions.create({
@@ -64,8 +64,10 @@ describe('sessions', () => {
           );
         })();
       },
-      user: 'bob@rob.com',
-    });
+      {
+        user: 'bob@rob.com',
+      },
+    );
 
     const storedData = submitLogSpy.mock.calls as any;
 
@@ -84,8 +86,8 @@ describe('sessions', () => {
 
   test('session with predefined sessionId', async () => {
     const predefinedSessionId = '15f75d3a-8007-4ff2-bada-0a27518ee668';
-    const { sessionId } = await baserun.session({
-      async session() {
+    const { sessionId } = await baserun.session(
+      async function () {
         await baserun.trace(async () => {
           baserun.log('lets go', 'omg');
           await openai.completions.create({
@@ -111,9 +113,11 @@ describe('sessions', () => {
           );
         })();
       },
-      user: 'bob@rob.com',
-      sessionId: predefinedSessionId,
-    });
+      {
+        user: 'bob@rob.com',
+        sessionId: predefinedSessionId,
+      },
+    );
 
     expect(sessionId).toBe(predefinedSessionId);
 
@@ -158,8 +162,7 @@ describe('sessions', () => {
       await Promise.all([trace(), trace()]);
     };
 
-    await baserun.session({
-      session,
+    await baserun.session(session, {
       user: 'bobby-brown@bobob.bob',
     });
 
@@ -206,13 +209,11 @@ describe('sessions', () => {
     };
 
     const [data1, data2] = await Promise.all([
-      baserun.session({
-        session,
+      baserun.session(session, {
         user: 'bobby-brown@bobob.bob',
         sessionId: sessionId1,
       }),
-      baserun.session({
-        session,
+      baserun.session(session, {
         user: 'bobby-brown@bobob.bob',
         sessionId: sessionId2,
       }),
@@ -223,11 +224,13 @@ describe('sessions', () => {
   });
 
   test('session with top level log', async () => {
-    await baserun.session({
-      async session() {
+    await baserun.session(
+      async function () {
         baserun.log('TestEvent', 'whatever');
       },
-      user: 'bobob',
-    });
+      {
+        user: 'bobob',
+      },
+    );
   });
 });


### PR DESCRIPTION
this pr addresses these 2 issues that were raised:

1. Is there any reason the data value from await baserun.session(...) is a Promise instead of the actual return value from the async callback? Having to write await data when it’s time to use it is a bit awkward.
>it was actually awaited, just types in function header didn't reflect it correctly

2. The API for creating / continuing a session is a bit verbose, is there any reason for it to not match baserun.trace() so that the first parameter is the callback and the second is the session options object? I feel it would be more consistent that way.
>moved the function from session options object to separate, first argument, so it should be more consistent with baserun.trace() now