### PR TITLE
allow completionId to be optional

### DIFF
--- a/src/baserun.ts
+++ b/src/baserun.ts
@@ -799,7 +799,7 @@ export class Baserun {
     store.evals.push(evalEntry);
   }
 
-  static annotate(completionId: string): Annotation {
+  static annotate(completionId?: string): Annotation {
     return new Annotation(completionId);
   }
 }


### PR DESCRIPTION
the reason is that after reading the docs one would expect it to work like that (and it does work like that in python sdk afaik)