### PR TITLE
Fix issue with synchronous code within trace

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -50,6 +50,7 @@ export class Annotation {
       }
     }
 
+    // TODO: why not use this.run?
     const run = Baserun.getOrCreateCurrentRun({ name: DEFAULT_RUN_NAME });
     const feedback: Feedback = {
       name: name ?? 'General Feedback',

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -50,15 +50,13 @@ export class Annotation {
       }
     }
 
-    // TODO: why not use this.run?
-    const run = Baserun.getOrCreateCurrentRun({ name: DEFAULT_RUN_NAME });
     const feedback: Feedback = {
       name: name ?? 'General Feedback',
       score,
       metadata: stringify(metadata ?? {}),
       endUser: undefined,
     };
-    if (run.sessionId) {
+    if (this.run.sessionId) {
       const endUser = Baserun.sessionLocalStorage.getStore()?.session?.endUser;
       if (endUser) {
         feedback.endUser = endUser;

--- a/src/baserun.ts
+++ b/src/baserun.ts
@@ -68,6 +68,15 @@ export type SessionOptions<T extends (...args: any[]) => any> = {
   session: T;
 };
 
+type RunOptions = {
+  name: string;
+  startTimestamp?: Date;
+  completionTimestamp?: Date;
+  traceType?: Run_RunType;
+  metadata?: object;
+  create?: boolean;
+};
+
 process.on('exit', () => {
   if (!global.baserunInitialized) {
     return;
@@ -290,7 +299,7 @@ export class Baserun {
     }
 
     return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
-      const run = Baserun.getOrCreateCurrentRun({
+      const run = await Baserun.getOrCreateCurrentRunWithEnsureCreated({
         name,
         traceType: isTestEnv() ? Run_RunType.TEST : Run_RunType.PRODUCTION,
         metadata,
@@ -419,21 +428,14 @@ export class Baserun {
     }
   }
 
-  static getOrCreateCurrentRun({
+  private static _getOrCreateCurrentRun({
     name,
     startTimestamp,
     completionTimestamp,
     traceType,
     metadata,
     create,
-  }: {
-    name: string;
-    startTimestamp?: Date;
-    completionTimestamp?: Date;
-    traceType?: Run_RunType;
-    metadata?: object;
-    create?: boolean;
-  }): Run {
+  }: RunOptions): { run: Run; isNew: boolean } {
     if (!global.baserunInitialized) {
       throw new Error(
         'Baserun has not been initialized. Ensure you call baserun.init() before using it.',
@@ -443,7 +445,7 @@ export class Baserun {
     const currentRun = Baserun.getCurrentRun();
     if (currentRun && !create) {
       debug('using existing run', currentRun);
-      return currentRun;
+      return { run: currentRun, isNew: false };
     }
 
     const runId = v4();
@@ -474,8 +476,20 @@ export class Baserun {
       run.startTimestamp = Timestamp.fromDate(completionTimestamp);
     }
 
-    Baserun.createRun(run);
+    return { run: run, isNew: true };
+  }
 
+  static getOrCreateCurrentRun(options: RunOptions): Run {
+    const { run, isNew } = this._getOrCreateCurrentRun(options);
+    isNew && Baserun.createRun(run);
+    return run;
+  }
+
+  static async getOrCreateCurrentRunWithEnsureCreated(
+    options: RunOptions,
+  ): Promise<Run> {
+    const { run, isNew } = this._getOrCreateCurrentRun(options);
+    isNew && (await Baserun.createRun(run));
     return run;
   }
 

--- a/src/jests/baserun/full_matrix.test.ts
+++ b/src/jests/baserun/full_matrix.test.ts
@@ -22,7 +22,7 @@ describe('Baserun end-to-end', () => {
   describe('openai-v4', () => {
     it('should suggest the Eiffel Tower', async () => {
       const completion = await api.completions.create({
-        model: 'text-davinci-003',
+        model: 'gpt-3.5-turbo-instruct',
         temperature: 0.7,
         prompt: 'What are three activities to do in Paris?',
       });
@@ -42,7 +42,7 @@ describe('Baserun end-to-end', () => {
 
     it('should suggest the Eiffel Tower Streaming', async () => {
       const completion = await api.completions.create({
-        model: 'text-davinci-003',
+        model: 'gpt-3.5-turbo-instruct',
         temperature: 0.7,
         prompt: 'What are three activities to do in Paris?',
         stream: true,


### PR DESCRIPTION
when you run synchronous code within a trace you risk that a request sent to create a run would timeout (as you'd block the other execution with your synchronous code). this can be easily observed in the example from the docs itself (example with chatbot - just don't hit enter for ~20s). this change ensures that a sending request routine is finished before running a callback given by a user and thus eliminating this risk